### PR TITLE
Missing requires in chef_provider_package_rbenvrubygems.rb

### DIFF
--- a/libraries/chef_provider_package_rbenvrubygems.rb
+++ b/libraries/chef_provider_package_rbenvrubygems.rb
@@ -19,6 +19,9 @@
 # limitations under the License.
 #
 
+require File.join(File.dirname(__FILE__) + '/chef_rbenv_mixin')
+require File.join(File.dirname(__FILE__) + '/chef_rbenv_script_helpers')
+
 class Chef
   class Provider
     class Package


### PR DESCRIPTION
Fixes the following problem:

```
NameError: uninitialized constant Chef::Rbenv
```
