### PR TITLE
os x compliance

### DIFF
--- a/libraries/chef_provider_package_rbenvrubygems.rb
+++ b/libraries/chef_provider_package_rbenvrubygems.rb
@@ -19,6 +19,10 @@
 # limitations under the License.
 #
 
+# on os x, this file throws an exception without those requires 
+require File.expand_path("../chef_rbenv_mixin", __FILE__)
+require File.expand_path("../chef_rbenv_script_helpers", __FILE__)
+
 class Chef
   class Provider
     class Package


### PR DESCRIPTION
I am currently using littlechef to configure my local machine. rbenv is one of my cookbooks. Although not being used for my local machine, it throws an exception. It seems, the libraries are not automatically included because I do not use the cookbook, but somehow the provider is required. Because the mixin and script_helpers was not required before, the provider throws an exception.
