### PR TITLE
Minor fix to add the configured user to rehash commands

### DIFF
--- a/libraries/chef_provider_package_rbenvrubygems.rb
+++ b/libraries/chef_provider_package_rbenvrubygems.rb
@@ -65,6 +65,7 @@ class Chef
         def install_package(name, version)
           super
           rbenv_rehash new_resource do
+            user rbenv_user if rbenv_user
             action :nothing
           end.run_action(:run)
           true
@@ -73,6 +74,7 @@ class Chef
         def remove_package(name, version)
           super
           rbenv_rehash new_resource do
+            user rbenv_user if rbenv_user
             action :nothing
           end.run_action(:run)
           true


### PR DESCRIPTION
Hi there,

I hit this last week whilst trying to install gems for a particular user - the `rbenv_rehash` commands in the `rbenv_gem` command didn't include the `user` parameter so were defaulting to the system install rbenv directory and failing.

This is a quick patch for that. Hope it's useful.
