### PR TITLE
librarian 0.0.14 chokes on the git:// uri/protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Include a reference to the cookbook in a [Cheffile][cheffile] and run
     librarian-chef init
     cat >> Cheffile <<END_OF_CHEFFILE
     cookbook 'rbenv',
-      :git => 'git://github.com/fnichol/chef-rbenv.git', :ref => 'v0.6.2'
+      :git => 'https://github.com/fnichol/chef-rbenv', :ref => 'v0.6.2'
     END_OF_CHEFFILE
     librarian-chef install
 


### PR DESCRIPTION
```
/src/taqtiqa/ttinit/vendor/ruby/1.9.1/gems/librarian-0.0.14/lib/librarian/source/git/repository.rb:102:in `block in run!': fatal: ambiguous argument 'v0.6.2': unknown revision or path not in the working tree. (StandardError)
```
