### PR TITLE
Set path for user install

### DIFF
--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -21,6 +21,12 @@ include_recipe 'rbenv'
 
 install_rbenv_pkg_prereqs
 
+template "/etc/profile.d/rbenv.sh" do
+  source  "rbenv.sh.erb"
+  owner   "root"
+  mode    "0755"
+end
+
 Array(node['rbenv']['user_installs']).each do |rb_user|
   upgrade_strategy  = build_upgrade_strategy(rb_user['upgrade'])
   git_url           = rb_user['git_url'] || node['rbenv']['git_url']

--- a/templates/default/rbenv.sh.erb
+++ b/templates/default/rbenv.sh.erb
@@ -4,10 +4,12 @@
 # prefer a user rbenv over a system wide install
 if [[ -s "${HOME}/.rbenv/bin" ]]; then
   rbenv_root="${HOME}/.rbenv"
-else
+elif [[ -s "<%= node['rbenv']['root_path'] %>" ]]; then
   rbenv_root="<%= node['rbenv']['root_path'] %>"
   export RBENV_ROOT="$rbenv_root"
 fi
 
-export PATH="${rbenv_root}/bin:$PATH"
-eval "$(rbenv init -)"
+if [ "$rbenv_root" != "" ]; then
+  export PATH="${rbenv_root}/bin:$PATH"
+  eval "$(rbenv init -)"
+fi


### PR DESCRIPTION
If you do a user install only (and no system install), then PATH won't get set for that user. This pull request includes `/etc/profile.d/rbenv.sh` for user installs too. I also modified that file so it won't change the path for users without rbenv installed when there is no system install.
