### PR TITLE
Don't call libexec commands directly

### DIFF
--- a/libraries/chef_rbenv_recipe_helpers.rb
+++ b/libraries/chef_rbenv_recipe_helpers.rb
@@ -78,7 +78,7 @@ class Chef
         end
 
         bash "Initialize rbenv (#{opts[:user] || 'system'})" do
-          code  %{PATH="#{prefix}/bin:$PATH" #{prefix}/libexec/rbenv-init -}
+          code  %{PATH="#{prefix}/bin:$PATH" rbenv init -}
           environment({'RBENV_ROOT' => prefix}.merge(init_env))
           user  opts[:user]   if opts[:user]
           group opts[:group]  if opts[:group]


### PR DESCRIPTION
The rbenv command sets up paths in order to execute libexec commands itself.

Fixes first run issues as a result of https://github.com/sstephenson/rbenv/commit/cf2813600391341ea13d927667b1f08cb0769610.
