### PR TITLE
Use the ruby name as the definition to install

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -25,8 +25,8 @@ Array(node['rbenv']['user_installs']).each do |rbenv_user|
 
   rubies.each do |rubie|
     if rubie.is_a?(Hash)
-      rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do
-        definition  rubie
+      rbenv_ruby "#{rubie['name']} (#{rbenv_user['user']})" do
+        definition  rubie['name']
         user        rbenv_user['user']
         root_path   rbenv_user['root_path'] if rbenv_user['root_path']
         environment rubie['environment'] if rubie['environment']


### PR DESCRIPTION
The docs show that you can pass in a hash containing the ruby name and some environment settings, to get the ruby built with those settings. However when running ruby user install and passing in environment settings the chef run would fail.

Given the json:

``` json
"rbenv": {
    "create_profiled": false,
    "user_installs": [
      {
        "user": "gavin",
        "rubies": [
          {
            "name": "1.9.3-p385", "environment": { "CC": "gcc" }
          }
        ],
        "global": "1.9.3-p385",
        "gems": {
          "1.9.3-p385": [
            { "name": "bundler" }
          ]
        }
      }
    ]
  }
```

The chef run would fail with:

``` shell
================================================================================
Recipe Compile Error in /tmp/chef/cookbooks/rbenv/recipes/user.rb
================================================================================


Chef::Exceptions::ValidationFailed
----------------------------------
Option definition must be a kind of String!  You passed {"name"=>"1.9.3-p385", "environmment"=>{"CC"=>"gcc"}}.


Cookbook Trace:
---------------
  /tmp/chef/cookbooks/rbenv/recipes/user.rb:29:in `block (3 levels) in from_file'
  /tmp/chef/cookbooks/rbenv/recipes/user.rb:28:in `block (2 levels) in from_file'
  /tmp/chef/cookbooks/rbenv/recipes/user.rb:26:in `each'
  /tmp/chef/cookbooks/rbenv/recipes/user.rb:26:in `block in from_file'
  /tmp/chef/cookbooks/rbenv/recipes/user.rb:22:in `each'
  /tmp/chef/cookbooks/rbenv/recipes/user.rb:22:in `from_file'


Relevant File Content:
----------------------
/tmp/chef/cookbooks/rbenv/recipes/user.rb:

 22:  Array(node['rbenv']['user_installs']).each do |rbenv_user|
 23:    rubies    = rbenv_user['rubies'] || node['rbenv']['user_rubies']
 24:    gem_hash  = rbenv_user['gems'] || node['rbenv']['user_gems']
 25:  
 26:    rubies.each do |rubie|
 27:      if rubie.is_a?(Hash)
 28:        rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do
 29>>         definition  rubie
 30:          user        rbenv_user['user']
 31:          root_path   rbenv_user['root_path'] if rbenv_user['root_path']
 32:          environment rubie['environment'] if rubie['environment']
 33:        end
 34:      else
 35:        rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do
 36:          definition  rubie
 37:          user        rbenv_user['user']
 38:          root_path   rbenv_user['root_path'] if rbenv_user['root_path']
```

This change ensures that the name key in the hash is used as the definition.
