### PR TITLE
Use run_context.loaded_recipe? to check for ruby_build

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -83,7 +83,7 @@ def ruby_installed?
 end
 
 def ruby_build_missing?
-  ! node.recipe?("ruby_build")
+  ! run_context.loaded_recipe?("ruby_build")
 end
 
 def install_ruby_dependencies


### PR DESCRIPTION
This allows you to use `include_recipe("ruby_build")` instead of having to put it in the `run_list`.

Fixes #31 and #35.
