### PR TITLE
Add a definition_file attribute to the rbenv_ruby resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -889,7 +889,14 @@ in the run list to perform the builds.
       <td>definition</td>
       <td>
         <b>Name attribute:</b> the name of a built-in definition<sup>(1)</sup>
-        or the path to a ruby-build definition file.
+        or the name of the ruby installed by a ruby-build defintion file<sup>(2)</sup>
+      </td>
+      <td><code>nil</code></td>
+    </tr>
+    <tr>
+      <td>definition_file</td>
+      <td>
+        The path to a ruby-build definition file.  
       </td>
       <td><code>nil</code></td>
     </tr>
@@ -915,6 +922,7 @@ in the run list to perform the builds.
 </table>
 
 1. [built-in definition][rb_definitions]
+2. the recipe checks for the existence of the naming attribute under the root_path, and if not found invokes ruby-build with the definition file as an argument
 
 #### <a name="lwrps-rbr-examples"></a> Examples
 
@@ -933,6 +941,12 @@ usage.
 
     rbenv_ruby "ree-1.8.7-2011.03" do
       action :reinstall
+    end
+
+##### Install a custom ruby
+
+    rbenv_ruby "2.0.0p116" do
+      definition_file "/usr/local/rbenv/custom/2.0.0p116"
     end
 
 ## <a name="mac-system-note"></a> System-Wide Mac Installation Note

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -23,6 +23,7 @@ include Chef::Rbenv::ScriptHelpers
 
 def load_current_resource
   @rubie      = new_resource.definition
+  @definition_file = new_resource.definition_file
   @root_path  = new_resource.root_path
   @user       = new_resource.user
   @environment = new_resource.environment
@@ -54,9 +55,10 @@ def perform_install
     # bypass block scoping issues
     rbenv_user    = @user
     rubie         = @rubie
+    definition    = @definition_file || @rubie
     rbenv_prefix  = @root_path
     rbenv_env     = @environment
-    command       = %{rbenv install #{rubie}}
+    command       = %{rbenv install #{definition}}
 
     rbenv_script "#{command} #{which_rbenv}" do
       code        command

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -22,6 +22,7 @@
 actions :install, :reinstall
 
 attribute :definition,  :kind_of => String, :name_attribute => true
+attribute :definition_file,	:kind_of => String
 attribute :root_path,   :kind_of => String
 attribute :user,        :kind_of => String
 attribute :environment, :kind_of => Hash


### PR DESCRIPTION
This prevents the recipe from continually trying to build a custom
ruby when passed a build file name instead of a built-in definition
