### PR TITLE
Allow String or Hash for ruby gem options

### DIFF
--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -26,7 +26,7 @@ attribute :rbenv_version, :kind_of => String, :default => "global"
 attribute :version,       :kind_of => String
 attribute :response_file, :kind_of => String
 attribute :source,        :kind_of => String
-attribute :options,       :kind_of => Hash
+attribute :options,       :kind_of => [String, Hash]
 attribute :gem_binary,    :kind_of => String
 attribute :user,          :kind_of => String
 attribute :root_path,     :kind_of => String


### PR DESCRIPTION
The Rubygems Chef provider allows either a String or Hash to be provided for options. In some circumstances, such as the omnibus install, it expects a String. This update allows either, since it is simply delegated anyway.
