### PR TITLE
Update Opscode documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -971,12 +971,12 @@ limitations under the License.
 [berkshelf]:        http://berkshelf.com/
 [chef_repo]:        https://github.com/opscode/chef-repo
 [cheffile]:         https://github.com/applicationsonline/librarian/blob/master/lib/librarian/chef/templates/Cheffile
-[gem_package_options]: http://wiki.opscode.com/display/chef/Resources#Resources-GemPackageOptions
+[gem_package_options]: http://docs.opscode.com/resource_gem_package.html#attributes
 [kgc]:              https://github.com/websterclay/knife-github-cookbooks#readme
 [librarian]:        https://github.com/applicationsonline/librarian#readme
-[lwrp]:             http://wiki.opscode.com/display/chef/Lightweight+Resources+and+Providers+%28LWRP%29
+[lwrp]:             http://docs.opscode.com/lwrp_custom.html
 [mac_profile_d]:    http://hints.macworld.com/article.php?story=20011221192012445
-[package_resource]: http://wiki.opscode.com/display/chef/Resources#Resources-Package
+[package_resource]: http://docs.opscode.com/resource_package.html
 [rb_readme]:        https://github.com/sstephenson/ruby-build#readme
 [rb_definitions]:   https://github.com/sstephenson/ruby-build/tree/master/share/ruby-build
 [rbenv_site]:       https://github.com/sstephenson/rbenv
@@ -985,7 +985,7 @@ limitations under the License.
 [rbenv_3_6]:        https://github.com/sstephenson/rbenv#section_3.6
 [ruby_build_cb]:    http://community.opscode.com/cookbooks/ruby_build
 [ruby_build_site]:  https://github.com/sstephenson/ruby-build
-[script_resource]:  http://wiki.opscode.com/display/chef/Resources#Resources-Script
+[script_resource]:  http://docs.opscode.com/resource_script.html
 
 [fnichol]:      https://github.com/fnichol
 [repo]:         https://github.com/fnichol/chef-rbenv


### PR DESCRIPTION
Most of the wiki.opscode.com links redirect, but not to the right place. This updates the links to the new documentation site.
