### PR TITLE
Fix some CHEF-3694 warnings when using with ruby_build

### DIFF
--- a/libraries/chef_rbenv_recipe_helpers.rb
+++ b/libraries/chef_rbenv_recipe_helpers.rb
@@ -40,7 +40,9 @@ class Chef
         return if mac_with_no_homebrew
 
         node['rbenv']['install_pkgs'].each do |pkg|
-          package pkg
+          package "installing rbenv dependency: #{pkg}" do
+            package_name pkg
+          end
         end
       end
 


### PR DESCRIPTION
This is from git-core package redefinition

[CHEF-3694](http://tickets.opscode.com/browse/CHEF-3694) warnings were caused by package resource re-definition with
same name as another cookbook.

I'd think that this is so common there would be a better way to avoid
this warning...
