### PR TITLE
fix behavior when ruby versions passed as hashes instead of string

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -25,8 +25,8 @@ Array(node['rbenv']['user_installs']).each do |rbenv_user|
 
   rubies.each do |rubie|
     if rubie.is_a?(Hash)
-      rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do
-        definition  rubie
+      rbenv_ruby "#{rubie.name} (#{rbenv_user['user']})" do
+        definition  rubie.name
         user        rbenv_user['user']
         root_path   rbenv_user['root_path'] if rbenv_user['root_path']
         environment rubie['environment'] if rubie['environment']


### PR DESCRIPTION
this fixes the handling of rubies when passed as hashes, i.e.

``` ruby
node['rbenv'] => {
  'user_rubies' => [
    { 'name' => 'ree-1.8.7-2012.02', 'environment' => { 'CONFIGURE_OPTS' => '--no-tcmalloc' }  }
  ]
}
```

and also the name passed to the rbenv_ruby lwrp whether it's a hash or a string.
