### PR TITLE
Support ruby 2.1.0

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -92,7 +92,7 @@ def install_ruby_dependencies
   definition = ::File.basename(new_resource.definition)
 
   case definition
-  when /^\d\.\d\.\d-/, /^rbx-/, /^ree-/
+  when /^\d\.\d\.\d/, /^rbx-/, /^ree-/
     pkgs = node['ruby_build']['install_pkgs_cruby']
   when /^jruby-/
     pkgs = node['ruby_build']['install_pkgs_jruby']


### PR DESCRIPTION
Fixes the installation of build dependencies for ruby 2.1.0.
The regex now matches against ruby versions without appended patchlevel.
