### PR TITLE
fix definition when the rubie is a Hash

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -26,7 +26,7 @@ Array(node['rbenv']['user_installs']).each do |rbenv_user|
   rubies.each do |rubie|
     if rubie.is_a?(Hash)
       rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do
-        definition  rubie
+        definition  rubie['name']
         user        rbenv_user['user']
         root_path   rbenv_user['root_path'] if rbenv_user['root_path']
         environment rubie['environment'] if rubie['environment']


### PR DESCRIPTION
fix definition when the rubie is a Hash
### Example

``` ruby
:rbenv => {
  :user_installs => [
    {
      :user   => "vagrant",
      :rubies => [
        {
          :name => '2.1.0',
          :environment => { 'CFLAGS' => '--disable-install-doc --enable-shared' }
        }
      ],
      :global => "2.1.0",
      'gems'  => {
        '2.1.0'    => [
          { 'name'    => 'bundler' }
        ]
      }
    }
  ]
}
```

Error
`Option definition must be a kind of String!  You passed {"name"=>"2.1.0"}.`
