### PR TITLE
fix user_install recipe allowing specifying a hash for a ruby install

### DIFF
--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -25,8 +25,8 @@ Array(node['rbenv']['user_installs']).each do |rbenv_user|
 
   rubies.each do |rubie|
     if rubie.is_a?(Hash)
-      rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do
-        definition  rubie
+      rbenv_ruby "#{rubie['name']} (#{rbenv_user['user']})" do
+        definition  rubie['name']
         user        rbenv_user['user']
         root_path   rbenv_user['root_path'] if rbenv_user['root_path']
         environment rubie['environment'] if rubie['environment']


### PR DESCRIPTION
Fix `recipe[rbenv::user]` recipe for use in scenario below:

```
node.default['rbenv']['user_rubies'] = [ "1.8.7-p352",
  {
  :name => '1.9.3-327',
  :environment => { 'CFLAGS' => '-march=native -O2 -pipe' }
  }
]
```
