### PR TITLE
Install user-specific gems as user

### DIFF
--- a/libraries/chef_provider_package_rbenvrubygems.rb
+++ b/libraries/chef_provider_package_rbenvrubygems.rb
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'etc'
 
 class Chef
   module Rbenv
@@ -63,13 +64,13 @@ class Chef
         end
 
         def install_package(name, version)
-          super
+          run_as_user(rbenv_user) { super }
           rehash
           true
         end
 
         def remove_package(name, version)
-          super
+          run_as_user(rbenv_user) { super }
           rehash
           true
         end

--- a/libraries/chef_rbenv_script_helpers.rb
+++ b/libraries/chef_rbenv_script_helpers.rb
@@ -60,6 +60,20 @@ class Chef
         r = yield
         new_resource.updated_by_last_action(r.updated_by_last_action?)
       end
+
+      # Execute the supplied block of code as the given user.
+      def run_as_user(username, &block)
+        if username
+          user = Etc.getpwnam(username)
+          Process.fork do
+            Process.uid = user.uid
+            block.call
+          end
+          Process.wait
+        else
+          block.call
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When specifying a gem to be installed for a user, the created gem
directory and its files would be owned by root instead of the user.

This is due to the fact that the `install_via_gem_command` and
`uninstall_via_gem_command` methods defined by the upstream Chef repo
don't specify a `user` to run the `gem install` command as. This has
been reported by the issue in [1], but there has been no response after
many months.

Unfortunately, there isn't a standard way of getting around this without
either monkey patching those definitions to specify the `user` option
when calling `shell_out!`, or committing some invasive changes to the
upstream Chef repository (specifically the `GemEnvironment` class that
the `RbenvGemEnvironment` extends).

A simple (but perhaps unorthodox) way around this is to fork the process
and change its `uid` to the desired username before executing the
installation/uninstallation code. This is accomplished by defining a
`run_as_user` helper that takes a username and a block and executes that
block in a forked process as the given username.

It tastes awful, and it works.

[1] https://github.com/fnichol/chef-rbenv/issues/61
