### PR TITLE
Add patching to builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ A url to a patch file for your ruby install.
 
 The default is `nil`.
 
-### <a name="attributes-patch_file"></a> patch_file_
+### <a name="attributes-patch_file"></a> patch_file
 
 A path to a patch file for your ruby install.
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,18 @@ The path prefix to rbenv in a system-wide installation.
 
 The default is `"/usr/local/rbenv"`.
 
+### <a name="attributes-patch_url"></a> patch_url
+
+A url to a patch file for your ruby install.
+
+The default is `nil`.
+
+### <a name="attributes-patch_file"></a> patch_file_
+
+A path to a patch file for your ruby install.
+
+The default is `nil`.
+
 ### <a name="attributes-rubies"></a> rubies
 
 A list of additional system-wide rubies to be built and installed using the

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -27,6 +27,8 @@ def load_current_resource
   @root_path  = new_resource.root_path
   @user       = new_resource.user
   @environment = new_resource.environment
+  @patch_url = new_resource.patch_url
+  @patch_file = new_resource.patch_file
 end
 
 action :install do
@@ -58,7 +60,18 @@ def perform_install
     definition    = @definition_file || @rubie
     rbenv_prefix  = @root_path
     rbenv_env     = @environment
-    command       = %{rbenv install #{definition}}
+
+    patch_command = nil
+
+    if @patch_url
+      patch_command = "--patch < <(curl -sSL #{@patch_url})"
+    end
+
+    if @patch_file
+      patch_command = "--patch < #{@patch_file}"
+    end
+
+    command       = %{rbenv install #{definition} #{patch_command}}
 
     rbenv_script "#{command} #{which_rbenv}" do
       code        command

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -40,6 +40,8 @@ Array(node['rbenv']['user_installs']).each do |rbenv_user|
         user        rbenv_user['user']
         root_path   rbenv_user['root_path'] if rbenv_user['root_path']
         environment rubie['environment'] if rubie['environment']
+        patch_url   rubie['patch_url'] if rubie['patch_url']
+        patch_file  rubie['patch_file'] if rubie['patch_file']
       end
     else
       rbenv_ruby "#{rubie} (#{rbenv_user['user']})" do

--- a/resources/ruby.rb
+++ b/resources/ruby.rb
@@ -26,6 +26,8 @@ attribute :definition_file,	:kind_of => String
 attribute :root_path,   :kind_of => String
 attribute :user,        :kind_of => String
 attribute :environment, :kind_of => Hash
+attribute :patch_url,   :kind_of => String
+attribute :patch_file,  :kind_of => String
 
 def initialize(*args)
   super


### PR DESCRIPTION
This isn't ready for merging, but I'd like to discuss if my approach is acceptable.

Ruby-build and `rbenv install` supports [patching ruby](https://github.com/sstephenson/ruby-build#applying-patches-to-ruby-before-compiling) before building it.

I'd like to make use of this in the rbenv cookbook as I've got a couple of rubies that are failing to build unless a patch is applied.

This PR would add support for supplying patch files or urls.

As it current stands it:
- ~~adds a dependency on `curl`~~
- has only been tested with user install (and it missing proper test support)

What do you think about this? Do you think using a separate file and url attribute is the right approach. ~~Are you happy with a curl dependency being added? (I'll check for a curl community cookbook).~~

Edit: Curl is included in ruby build cookbook, which this section of the code depends on :)
