### PR TITLE
Update ruby versions and add centos 7

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ platforms:
   run_list:
   - recipe[apt]
 - name: centos-6.5
+- name: centos-7.0
 
 suites:
 - name: system_ruby
@@ -22,10 +23,10 @@ suites:
       - name: rbenv-vars
         git_url: https://github.com/sstephenson/rbenv-vars.git
       rubies:
-      - name: 2.1.1
+      - name: 2.1.6
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
-      - name: ree-1.8.7-2012.02
+      - name: 2.2.2
         environment:
-          CONFIGURE_OPTS: --no-tcmalloc --no-dev-docs
-      global: 2.1.1
+          CONFIGURE_OPTS: --disable-install-rdoc
+      global: 2.1.6


### PR DESCRIPTION
ruby enterprise edition is 3 years EOL.  Test on 2.1.6 and 2.2.2 instead
