### PR TITLE
Revert "Use multipackage support in Chef 12.1"

### DIFF
--- a/libraries/chef_rbenv_recipe_helpers.rb
+++ b/libraries/chef_rbenv_recipe_helpers.rb
@@ -39,7 +39,11 @@ class Chef
       def install_rbenv_pkg_prereqs
         return if mac_with_no_homebrew
 
-        package node['rbenv']['install_pkgs']
+        node['rbenv']['install_pkgs'].each do |pkg|
+          package "installing rbenv dependency: #{pkg}" do
+            package_name pkg
+          end
+        end
       end
 
       def install_or_upgrade_rbenv(opts = {})


### PR DESCRIPTION
We ran into the same issue described in https://github.com/chef-rbenv/ruby_rbenv/issues/139. Multipackage doesn't appear to be supported/work for Homebrew. This PR reverts the problem bit.

And actually, looks like this change is also part of https://github.com/chef-rbenv/ruby_rbenv/pull/137
