### PR TITLE
Use https: instead of git: and use the correct url for rbenv

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 #
 
 # git repository containing rbenv
-default['rbenv']['git_url'] = 'git://github.com/sstephenson/rbenv.git'
+default['rbenv']['git_url'] = 'https://github.com/rbenv/rbenv.git'
 default['rbenv']['git_ref'] = 'v0.4.0'
 
 # upgrade action strategy


### PR DESCRIPTION
Using Windows 8, following along with this guide:  https://gorails.com/guides/using-vagrant-for-rails-development and updating it to use ruby_rbenv I ran into this error: 

```
==> default: [2016-07-12T14:51:03+00:00] ERROR: git[/usr/local/rbenv] (ruby_rbenv::system_install line 60) had an error: Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0], but received '128'
==> default: ---- Begin output of git ls-remote "git://github.com/sstephenson/rbenv.git" "v0.4.0*" ----
==> default: STDOUT:
==> default: STDERR: fatal: unable to connect to github.com:
==> default: github.com[0: 192.30.253.112]: errno=Connection timed out
==> default: ---- End output of git ls-remote "git://github.com/sstephenson/rbenv.git" "v0.4.0*" ----
==> default: Ran git ls-remote "git://github.com/sstephenson/rbenv.git" "v0.4.0*" returned 128
```
