### PR TITLE
Expand platforms to test on but remove RHEL 6

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,6 +8,13 @@ platforms:
   - name: centos-5.11
   - name: centos-6.7
   - name: centos-7.2
+  - name: debian-7.10
+    run_list: apt::default
+  - name: debian-8.4
+    run_list: apt::default
+  - name: fedora-23
+    run_list: yum::dnf_yum_compat
+  - name: opensuse-13.2
   - name: ubuntu-12.04
     run_list: apt::default
   - name: ubuntu-14.04

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ services: docker
 
 env:
   matrix:
-    - INSTANCE=system-ruby-centos-6
     - INSTANCE=system-ruby-centos-7
+    - INSTANCE=system-ruby-debian-7
+    - INSTANCE=system-ruby-debian-8
+    - INSTANCE=system-ruby-fedora-latest
+    - INSTANCE=system-ruby-opensuse-132
+    - INSTANCE=system-ruby-opensuse-421
     - INSTANCE=system-ruby-ubuntu-1204
     - INSTANCE=system-ruby-ubuntu-1404
     - INSTANCE=system-ruby-ubuntu-1604

--- a/Berksfile
+++ b/Berksfile
@@ -4,7 +4,6 @@ metadata
 group :integration do
   cookbook 'apt'
   cookbook 'yum'
-  cookbook 'java'
 end
 
 cookbook 'fixtures', path: 'test/unit/fixtures'


### PR DESCRIPTION
RHEL 6 times out, but passes locally. Removing it for now.

Signed-off-by: Tim Smith tsmith@chef.io
