### PR TITLE
dont do a rbenv user install if the path does not exist: closes #149

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [Unreleased]
+
+- added checks to user install recipes to avoid breaking if the rbenv_home does not exist
+
 # 1.1.0 (July 17, 2016)
 
 - Restored compatibility for platforms that don't yet support multipackage installs in Chef (BSD and OS X in particular)

--- a/recipes/user.rb
+++ b/recipes/user.rb
@@ -20,6 +20,11 @@
 include_recipe 'ruby_rbenv::user_install'
 
 Array(node['rbenv']['user_installs']).each do |rbenv_user|
+  if rbenv_user['home'].nil?
+    next unless ::File.exist?(File.join(node['rbenv']['user_home_root'], rbenv_user['user']))
+  else
+    next unless ::File.exist?(rbenv_user['home'])
+  end
   plugins   = rbenv_user['plugins'] || node['rbenv']['user_plugins']
   rubies    = rbenv_user['rubies'] || node['rbenv']['user_rubies']
   gem_hash  = rbenv_user['gems'] || node['rbenv']['user_gems']

--- a/recipes/user_install.rb
+++ b/recipes/user_install.rb
@@ -29,6 +29,11 @@ template '/etc/profile.d/rbenv.sh' do
 end
 
 Array(node['rbenv']['user_installs']).each do |rb_user|
+  if rb_user['home'].nil?
+    next unless ::File.exist?(File.join(node['rbenv']['user_home_root'], rb_user['user']))
+  else
+    next unless ::File.exist?(rb_user['home'])
+  end
   upgrade_strategy  = build_upgrade_strategy(rb_user['upgrade'])
   git_url           = rb_user['git_url'] || node['rbenv']['git_url']
   git_ref           = rb_user['git_ref'] || node['rbenv']['git_ref']


### PR DESCRIPTION
To better allow people to use the attribute driven user installs of ruby we check to make sure the rbenv home exists before making it.
