### PR TITLE
Fix service provider for mac_os_x on chef 12

### DIFF
--- a/libraries/chef_rbenv_recipe_helpers.rb
+++ b/libraries/chef_rbenv_recipe_helpers.rb
@@ -32,7 +32,7 @@ class Chef
 
       def mac_with_no_homebrew
         node['platform'] == 'mac_os_x' &&
-          Chef::Platform.find_provider_for_node(node, :package) !=
+          Chef::Resource.resource_for_node(:service, node) !=
             Chef::Provider::Package::Homebrew
       end
 


### PR DESCRIPTION
Fix for an issue with installation on mac OS under chef 12. Also discussed here:

https://github.com/chef/chef/issues/3257
https://github.com/martinisoft/chef-rvm/issues/353