### PR TITLE
Test with Chef 12, upgrade chefDK on Travis, fix local Ubuntu 16.04 testing

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -68,6 +68,15 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
+- name: ubuntu-16.04-chef-12
+  driver:
+    image: ubuntu:16.04
+    chef_version: 12
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+
 - name: opensuse-leap
   driver:
     image: opensuse:leap

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,7 +1,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: current
+  chef_version: <%= ENV['CHEF_VERSION'] || "current" %>
 
 transport:
   name: dokken
@@ -63,15 +63,6 @@ platforms:
 - name: ubuntu-16.04
   driver:
     image: ubuntu:16.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
-
-- name: ubuntu-16.04-chef-12
-  driver:
-    image: ubuntu:16.04
-    chef_version: 12
     pid_one_command: /bin/systemd
     intermediate_instructions:
       - RUN /usr/bin/apt-get update

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,10 +19,13 @@ platforms:
       box: bento/ubuntu-16.04
     provisioner:
       require_chef_omnibus: 12
+    transport:
+      username: ubuntu
 
 suites:
 - name: system_ruby
   run_list:
+  - recipe[apt]
   - recipe[ruby_build]
   - recipe[ruby_rbenv::system]
   attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,11 @@ platforms:
   - name: centos-7.3
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: ubuntu-16.04-chef-12
+    driver_config:
+      box: bento/ubuntu-16.04
+    provisioner:
+      require_chef_omnibus: 12
   - name: fedora-25
 
 suites:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,9 +5,13 @@ provisioner:
   name: chef_zero
   deprecations_as_errors: true
 
+verifier:
+  name: inspec
+
 platforms:
   - name: centos-6.8
   - name: centos-7.3
+  - name: fedora-25
   - name: ubuntu-14.04
   - name: ubuntu-16.04
   - name: ubuntu-16.04-chef-12
@@ -15,7 +19,6 @@ platforms:
       box: bento/ubuntu-16.04
     provisioner:
       require_chef_omnibus: 12
-  - name: fedora-25
 
 suites:
 - name: system_ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ services: docker
 
 env:
   matrix:
-    #    - INSTANCE=system-ruby-centos-6
     - INSTANCE=system-ruby-centos-7
     - INSTANCE=system-ruby-ubuntu-1404
     - INSTANCE=system-ruby-ubuntu-1604
-    - INSTANCE=system-ruby-ubuntu-1604-chef-12
+    - INSTANCE=system-ruby-ubuntu-1604 CHEF_VERSION=12.7.2
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: trusty
 addons:
   apt:
     sources:
-      - chef-stable-trusty
+      - chef-current-trusty
     packages:
       - chefdk
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     - INSTANCE=system-ruby-centos-7
     - INSTANCE=system-ruby-ubuntu-1404
     - INSTANCE=system-ruby-ubuntu-1604
+    - INSTANCE=system-ruby-ubuntu-1604-chef-12
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Sous Chefs'
 maintainer_email 'help@sous-chefs.org'
 issues_url 'https://github.com/sous-chefs/ruby_rbenv/issues'
 source_url 'https://github.com/sous-chefs/ruby_rbenv'
-license 'Apache 2.0'
+license 'Apache-2.0'
 description 'Manages rbenv and its installed rubies. Several LWRPs are also defined.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '1.2.0'

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -81,8 +81,6 @@ def perform_install
 
     Chef::Log.debug("#{new_resource} build time was " \
       "#{(Time.now - install_start) / 60.0} minutes")
-
-    new_resource.updated_by_last_action(true)
   end
 end
 


### PR DESCRIPTION
### Description

Tests the cookbook with Chef 12 as well. Mainly so we can verify this cookbook keeps working once #161 is fixed.

What I'm wondering is how this currently passes on master, I see [the test run](https://travis-ci.org/sous-chefs/ruby_rbenv/jobs/243763740) but also the `Test Summary: 0 successful, 0 failures, 0 skipped`, so I'm not sure if it's doing anything at all. Since I'm new to kitchen, maybe somebody can resolve this for me?

### Issues Resolved

_none_

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable