### PR TITLE
Fix for issue #161 on Chef 13

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -89,7 +89,7 @@ suites:
       - name: 2.1.6
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
-      - name: 2.2.2
+      - name: 2.4.1
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
       global: 2.1.6

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -93,3 +93,7 @@ suites:
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
       global: 2.1.6
+      gems:
+        '2.4.1':
+          - name: bundler
+            action: upgrade

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -37,7 +37,7 @@ suites:
       - name: 2.1.6
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
-      - name: 2.2.2
+      - name: 2.4.1
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
       global: 2.1.6

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -41,3 +41,7 @@ suites:
         environment:
           CONFIGURE_OPTS: --disable-install-rdoc
       global: 2.1.6
+      gems:
+        '2.4.1':
+          - name: bundler
+            action: upgrade

--- a/libraries/chef_provider_package_rbenvrubygems.rb
+++ b/libraries/chef_provider_package_rbenvrubygems.rb
@@ -82,7 +82,7 @@ class Chef
         end
 
         def rehash
-          e = ::Chef::Resource::RubyRbenvRehash.new(new_resource.name, @run_context)
+          e = ::Chef::Resource.resource_for_node(:rbenv_rehash, node).new(new_resource.name, @run_context)
           e.root_path rbenv_root
           e.user rbenv_user if rbenv_user
           e.action :nothing

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -24,17 +24,18 @@ default_action :install
 
 provides :rbenv_gem
 
-attribute :package_name,  kind_of: String, name_attribute: true
-attribute :rbenv_version, kind_of: String, default: 'global'
-attribute :version,       kind_of: String
-attribute :response_file, kind_of: String
-attribute :source,        kind_of: String
-attribute :options,       kind_of: [String, Hash]
-attribute :gem_binary,    kind_of: String
-attribute :user,          kind_of: String
-attribute :root_path,     kind_of: String
-attribute :clear_sources, kind_of: [TrueClass, FalseClass]
-attribute :timeout,       kind_of: Integer, default: 300
+attribute :package_name,           kind_of: String, name_attribute: true
+attribute :rbenv_version,          kind_of: String, default: 'global'
+attribute :version,                kind_of: String
+attribute :response_file,          kind_of: String
+attribute :source,                 kind_of: String
+attribute :options,                kind_of: [String, Hash]
+attribute :gem_binary,             kind_of: String
+attribute :user,                   kind_of: String
+attribute :root_path,              kind_of: String
+attribute :clear_sources,          kind_of: [TrueClass, FalseClass]
+attribute :timeout,                kind_of: Integer, default: 300
+attribute :include_default_source, kind_of: [TrueClass, FalseClass]
 
 include Chef::Rbenv::Mixin::ResourceString
 

--- a/resources/rehash.rb
+++ b/resources/rehash.rb
@@ -22,7 +22,7 @@
 actions :run
 default_action :run
 
-provides :rbenv_rehash
+resource_name :rbenv_rehash
 
 attribute :name,      kind_of: String, name_attribute: true
 attribute :user,      kind_of: String


### PR DESCRIPTION
### Description

Installing a gem is not possible with Chef 13 currently. This PR aims to fix this.

### Issues Resolved

Fixes #161

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable