### PR TITLE
Group support on user install

### DIFF
--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -22,6 +22,7 @@
 property :git_url, String, default: 'https://github.com/rbenv/rbenv.git'
 property :git_ref, String, default: 'master'
 property :user, String, name_property: true
+property :group, String, default: lazy { user }
 property :home_dir, String, default: lazy { ::File.expand_path("~#{user}") }
 property :user_prefix, String, default: lazy { ::File.join(home_dir, '.rbenv') }
 property :update_rbenv, [true, false], default: true
@@ -49,14 +50,14 @@ action :install do
     reference new_resource.git_ref
     action :checkout if new_resource.update_rbenv == false
     user new_resource.user
-    group new_resource.user
+    group new_resource.group
     notifies :run, 'ruby_block[Add rbenv to PATH]', :immediately
   end
 
   %w(plugins shims versions).each do |d|
     directory "#{new_resource.user_prefix}/#{d}" do
       owner new_resource.user
-      group new_resource.user
+      group new_resource.group
       mode '0755'
     end
   end


### PR DESCRIPTION
### Description

Add group support to user installs (currently defaults to username, which is not always the case).

### Issues Resolved

There is no issue reporting this, but if you try to install with a user which group is different from his name you get an error:

```
`getgrnam': can't find group for xx
```

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/183)
<!-- Reviewable:end -->
