### PR TITLE
Missing jruby deps for RedHat flavors

### DIFF
--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -3,6 +3,8 @@ class Chef
     module PackageDeps
       def jruby_package_deps
         case node['platform_family']
+        when 'rhel', 'fedora', 'amazon'
+          %w(make gcc-c++)
         when 'debian'
           %w(make g++)
         when 'freebsd'


### PR DESCRIPTION
### Description

Package dependencies were missing for Red Hat varieties.

### Issues Resolved

N/A

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/191)
<!-- Reviewable:end -->
