### PR TITLE
Run gem resource commands as a local rbenv user

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -75,6 +75,7 @@ platforms:
 suites:
 - name: gem
   run_list:
+    - recipe[test::dokken]
     - recipe[test::gem]
   includes: [centos-7]
 - name: global

--- a/libraries/chef_rbenv_script_helpers.rb
+++ b/libraries/chef_rbenv_script_helpers.rb
@@ -30,20 +30,6 @@ class Chef
         ].join(' && ')
       end
 
-      # Execute the supplied block of code as the given user.
-      def run_as_user(username)
-        if username
-          user = Etc.getpwnam(username)
-          Process.fork do
-            Process.uid = user.uid
-            yield
-          end
-          Process.wait
-        else
-          yield
-        end
-      end
-
       def root_path
         node.run_state['root_path'] ||= {}
 

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -110,6 +110,7 @@ action_class do
   include Chef::Rbenv::ScriptHelpers
 
   def binary
-    "#{root_path}/versions/#{new_resource.rbenv_version}/bin/gem"
+    prefix = new_resource.user ? "sudo -u #{new_resource.user} " : ''
+    "#{prefix}#{root_path}/versions/#{new_resource.rbenv_version}/bin/gem"
   end
 end

--- a/test/fixtures/cookbooks/test/recipes/gem.rb
+++ b/test/fixtures/cookbooks/test/recipes/gem.rb
@@ -1,7 +1,11 @@
 rbenv_system_install 'system'
+rbenv_user_install 'vagrant'
 
 rbenv_ruby '2.4.1'
 rbenv_ruby '2.3.1'
+rbenv_ruby '2.3.1' do
+  user 'vagrant'
+end
 
 rbenv_global '2.4.1'
 
@@ -15,4 +19,10 @@ rbenv_gem 'mail' do
   version '2.6.6'
   rbenv_version '2.3.1'
   action :remove
+end
+
+rbenv_gem 'bundler' do
+  version '1.15.4'
+  user 'vagrant'
+  rbenv_version '2.3.1'
 end

--- a/test/integration/gem/controls/gem_install.rb
+++ b/test/integration/gem/controls/gem_install.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 global_ruby = '2.4.1'
 
-control 'Gem Install' do
+control 'Global Gem Install' do
   title 'Should install Mail Gem globally'
 
   desc "Can set global Ruby version to #{global_ruby}"
@@ -28,5 +28,15 @@ control 'Gem Install' do
   describe bash('source /etc/profile.d/rbenv.sh && gem env home') do
     its('exit_status') { should eq 0 }
     its('stdout') { should match(%r{/usr/local/rbenv/versions/#{Regexp.quote(global_ruby)}/lib/ruby/gems/2.4.0}) }
+  end
+end
+
+control 'User Gem Install' do
+  title 'Should install Bundler Gem to a user home'
+
+  desc 'Gemspec file should have correct ownership'
+  describe file('/home/vagrant/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/specifications/bundler-1.15.4.gemspec') do
+    it { should exist }
+    it { should be_owned_by 'vagrant' }
   end
 end


### PR DESCRIPTION
### Description

Looks like previously `run_as_user` was used to install gems for local rbenv installation. It's not used anymore so using `gem` resource runs commands as root. This change adds a `sudo -i` to a gem binary so it's ran as a specified user, producing correct permissions.

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/193)
<!-- Reviewable:end -->
