### PR TITLE
Missing tar package for CentOS 6.7

### DIFF
--- a/resources/system_install.rb
+++ b/resources/system_install.rb
@@ -76,7 +76,7 @@ action_class do
   def package_prerequisites
     case node['platform_family']
     when 'rhel', 'fedora', 'amazon', 'arch'
-      %w(git grep)
+      %w(git grep tar)
     when 'debian', 'suse'
       %w(git-core grep)
     when 'mac_os_x', 'gentoo'

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -83,7 +83,7 @@ action_class do
   def package_prerequisites
     case node['platform_family']
     when 'rhel', 'fedora', 'amazon'
-      %w(git grep)
+      %w(git grep tar)
     when 'debian', 'suse'
       %w(git-core grep)
     when 'mac_os_x'


### PR DESCRIPTION
### Description

Installs `tar` package missing in CentOS 6.7

### Issues Resolved

Issue is not created, but it is easy to check that `tar` is not exists in CentOS 6.7

`docker run -it --rm centos:6.7 sh -c 'tar'`

### Contribution Check List

- [x] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/194)
<!-- Reviewable:end -->
