### PR TITLE
switch ubuntu18.04 to use libgdbm5 and libssl1.0-dev

### DIFF
--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -37,7 +37,12 @@ class Chef
         when 'rhel', 'fedora', 'amazon'
           %w(gcc bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel make)
         when 'debian'
-          %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev make)
+          case node['platform_version']
+          when '18.04'
+            %w(gcc autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev make)
+          else
+            %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev make)
+          end
         when 'suse'
           %w(gcc make automake gdbm-devel libyaml-devel ncurses-devel readline-devel zlib-devel libopenssl-devel )
         end


### PR DESCRIPTION
### Description

ubuntu 18.04 doesn't have libgdbm3, and ssl 1.1 by default

This PR switches ubuntu 18.04 to use libgdbm5 and install the package libssl1.0-dev, which seem to work.

I haven't run tests on this PR - not set up for it.

### Issues Resolved

https://github.com/sous-chefs/ruby_rbenv/issues/207

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/208)
<!-- Reviewable:end -->
