### PR TITLE
Fix version default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.8 (2018-03-30)
+
+- Add back rbenv_version default to global, previously removed in v2.0.2
+
 # 2.0.7 (2018-03-11)
 
 - Adding Ubuntu 18.04 support

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/sous-chefs/ruby_rbenv'
 license 'Apache-2.0'
 description 'Manages rbenv and installs Rbenv based Rubies'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.7'
+version '2.0.8'
 chef_version '>= 12.9' if respond_to?(:chef_version)
 
 supports 'ubuntu'

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -33,7 +33,7 @@ property :timeout,                Integer, default: 300
 property :version,                String
 property :response_file,          String # Only used to reconfig
 property :user,                   String
-property :rbenv_version,          String
+property :rbenv_version,          String, default: 'global'
 
 default_action :install
 

--- a/test/fixtures/cookbooks/test/recipes/gem.rb
+++ b/test/fixtures/cookbooks/test/recipes/gem.rb
@@ -11,6 +11,10 @@ rbenv_global '2.4.1'
 
 rbenv_gem 'mail' do
   version '2.6.5'
+end
+
+rbenv_gem 'mail' do
+  version '2.6.5'
   options '--no-rdoc --no-ri'
   rbenv_version '2.3.1'
 end


### PR DESCRIPTION
### Description

Add back rbenv_version default to global, previously removed in v2.0.2. This continues to perform what the documentation says it will do

### Issues Resolved

#210 

### Contribution Check List

- [ ] All tests pass.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/211)
<!-- Reviewable:end -->
