### PR TITLE
Always set the include_default_source

### DIFF
--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -18,4 +18,4 @@ verifier:
 suites:
   - name: default
     run_list:
-      - recipe[test::default]
+      - recipe[test::gem]

--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -2,9 +2,8 @@ driver:
   name: proxy
   host: localhost
   reset_command: "exit 0"
-  port: <%= ENV["winrm_port"] %>
-  username: <%= ENV["winrm_user"] %>
-  password: <%= ENV["winrm_pass"] %>
+  username: <%= ENV["machine_user"] %>
+  password: <%= ENV["machine_pass"] %>
 
 provisioner:
   name: chef_zero

--- a/.kitchen.appveyor.yml
+++ b/.kitchen.appveyor.yml
@@ -2,6 +2,7 @@ driver:
   name: proxy
   host: localhost
   reset_command: "exit 0"
+  port: <%= ENV["winrm_port"] %>
   username: <%= ENV["machine_user"] %>
   password: <%= ENV["machine_pass"] %>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 environment:
   machine_user: vagrant
   machine_pass: vagrant
+  winrm_por: 5986
   KITCHEN_YAML: .kitchen.appveyor.yml
 
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,8 @@ test_script:
   - c:\opscode\chefdk\bin\cookstyle --version
   - c:\opscode\chefdk\bin\chef.bat exec foodcritic --version
   - c:\opscode\chefdk\bin\chef.bat exec delivery local all
+  - delivery local all
+  - ls
   - c:\opscode\chefdk\bin\chef.bat exec kitchen verify
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   machine_user: vagrant
   machine_pass: vagrant
-  winrm_por: 5985
+  winrm_port: 5985
   KITCHEN_YAML: .kitchen.appveyor.yml
 
 branches:
@@ -31,11 +31,9 @@ build_script:
   - ps: c:\opscode\chefdk\bin\chef.bat shell-init powershell | iex; cmd /c c:\opscode\chefdk\bin\chef.bat --version
 
 test_script:
-  - c:\opscode\chefdk\bin\cookstyle --version
-  - c:\opscode\chefdk\bin\chef.bat exec foodcritic --version
-  - c:\opscode\chefdk\bin\chef.bat exec delivery local all
+  - cookstyle --version
+  - foodcritic --version
   - delivery local all
-  - ls
-  - c:\opscode\chefdk\bin\chef.bat exec kitchen verify
+  - kitchen verify
 
 deploy: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   machine_user: vagrant
   machine_pass: vagrant
-  winrm_por: 5986
+  winrm_por: 5985
   KITCHEN_YAML: .kitchen.appveyor.yml
 
 branches:

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -93,7 +93,6 @@ class Chef
         end
       end
 
-      # rubocop:disable Style/GuardClause
       def ruby_installed?
         if Array(new_resource.action).include?(:reinstall)
           return false
@@ -103,7 +102,6 @@ class Chef
 
         false
       end
-      # rubocop:enable Style/GuardClause
 
       def verbose
         return '-v' if new_resource.verbose

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -26,7 +26,7 @@ provides :rbenv_gem
 # https://docs.chef.io/resource_gem_package.html#attributes
 property :clear_sources,          [true, false]
 property :include_default_source, [true, false], default: true
-property :ignore_failures,        [true, false], default: false
+property :ignore_failure, [true, false], default: false
 property :options,                [String, Hash]
 property :package_name,           [String, Array], name_property: true
 property :source,                 [String, Array]
@@ -41,7 +41,7 @@ default_action :install
 action :install do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    ignore_failure new_resource.ignore_failure if new_resource.ignore_failure
     include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
@@ -56,7 +56,7 @@ end
 action :purge do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    ignore_failure new_resource.ignore_failure if new_resource.ignore_failure
     include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
@@ -71,7 +71,7 @@ end
 action :reconfig do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    ignore_failure new_resource.ignore_failure if new_resource.ignore_failure
     include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
@@ -87,7 +87,7 @@ end
 action :remove do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    ignore_failure new_resource.ignore_failure if new_resource.ignore_failure
     include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
@@ -102,7 +102,7 @@ end
 action :upgrade do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    ignore_failure new_resource.ignore_failure if new_resource.ignore_failure
     include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options

--- a/resources/gem.rb
+++ b/resources/gem.rb
@@ -25,7 +25,8 @@ provides :rbenv_gem
 # Standard Gem Package Options
 # https://docs.chef.io/resource_gem_package.html#attributes
 property :clear_sources,          [true, false]
-property :include_default_source, [true, false]
+property :include_default_source, [true, false], default: true
+property :ignore_failures,        [true, false], default: false
 property :options,                [String, Hash]
 property :package_name,           [String, Array], name_property: true
 property :source,                 [String, Array]
@@ -40,7 +41,8 @@ default_action :install
 action :install do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    include_default_source new_resource.include_default_source if new_resource.include_default_source
+    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
     package_name new_resource.package_name if new_resource.package_name
@@ -54,7 +56,8 @@ end
 action :purge do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    include_default_source new_resource.include_default_source if new_resource.include_default_source
+    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
     package_name new_resource.package_name if new_resource.package_name
@@ -68,7 +71,8 @@ end
 action :reconfig do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    include_default_source new_resource.include_default_source if new_resource.include_default_source
+    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
     package_name new_resource.package_name if new_resource.package_name
@@ -83,7 +87,8 @@ end
 action :remove do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    include_default_source new_resource.include_default_source if new_resource.include_default_source
+    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
     package_name new_resource.package_name if new_resource.package_name
@@ -97,7 +102,8 @@ end
 action :upgrade do
   gem_package new_resource.package_name do
     clear_sources new_resource.clear_sources if new_resource.clear_sources
-    include_default_source new_resource.include_default_source if new_resource.include_default_source
+    ignore_failures new_resource.ignore_failures if new_resource.ignore_failures
+    include_default_source new_resource.include_default_source
     gem_binary binary
     options new_resource.options if new_resource.options
     package_name new_resource.package_name if new_resource.package_name

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -71,7 +71,7 @@ action :install do
     action :nothing
   end
 
-  bash 'Initialize user #{new_resource.user} rbenv' do
+  bash "Initialize user #{new_resource.user} rbenv" do
     code %(PATH="#{new_resource.user_prefix}/bin:$PATH" rbenv init -)
     environment('RBENV_ROOT' => new_resource.user_prefix)
     action :nothing

--- a/test/fixtures/cookbooks/test/recipes/dokken.rb
+++ b/test/fixtures/cookbooks/test/recipes/dokken.rb
@@ -8,5 +8,5 @@ end
 directory '/home/vagrant' do
   owner 'vagrant'
   group 'vagrant'
-  not_if { node['platform_family'] == 'windows' }
+  not_if { platform?('windows') }
 end

--- a/test/fixtures/cookbooks/test/recipes/dokken.rb
+++ b/test/fixtures/cookbooks/test/recipes/dokken.rb
@@ -8,5 +8,5 @@ end
 directory '/home/vagrant' do
   owner 'vagrant'
   group 'vagrant'
-  not_if { platform?('windows') }
+  not_if { node['platform_family'] == 'windows' }
 end

--- a/test/fixtures/cookbooks/test/recipes/dokken.rb
+++ b/test/fixtures/cookbooks/test/recipes/dokken.rb
@@ -8,4 +8,5 @@ end
 directory '/home/vagrant' do
   owner 'vagrant'
   group 'vagrant'
+  not_if { platform?('windows') }
 end


### PR DESCRIPTION
### Description

- Always set `include_default_source`, and set it to true (the default
in the underlying resource
- Add `ignore_failure` property. default it to false, as per the
underlying resource

### Issues Resolved

#215 

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/216)
<!-- Reviewable:end -->
