### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,24 @@ Runs a rbenv aware script.
 ```ruby
 rbenv_script 'foo' do
   rbenv_version #rbenv version to run the script against
-  environment # Optional: Environment to setup to run the script
+  environment # Optional: A Hash of environment variables in the form of ({"ENV_VARIABLE" => "VALUE"}).
   user # Optional: User to run as
   group # Optional: Group to run as
-  path # Optional: User to run as
   returns # Optional: Expected return code
   code # Script code to run
 end
 ```
+Note that environment overwrites the entire variable.
+For example. setting the $PATH variable can be done like this:
+```ruby
+rbenv_script 'bundle package' do
+  cwd node["bundle_dir"]
+  environment ({"PATH" => "/usr/local/rbenv/shims:/usr/local/rbenv/bin:#{ENV["PATH"]}"})
+  code "bundle package --all"
+end
+```
+Where `#{ENV["PATH"]}` appends the existing PATH to the end of the newly set PATH.
+
 
 ## System_install
 


### PR DESCRIPTION
Add explanation of how to use the "environment" option of "rbenv_script". with example of setting $PATH

### Description

Explains the basic use of the rbenv_script function

### Issues Resolved

When I tried to use rbenv_script, I spent a long time trying to get it to work as a non-root user, because I kept getting path errors.
This change lets users know how they can use rbenv_script without having to spend time figuring it out.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/223)
<!-- Reviewable:end -->
