### PR TITLE
Make it possible to uninstall, fixes #189

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -26,6 +26,9 @@ suites:
   includes: [centos-7]
 - name: global
   run_list: recipe[test::global]
+- name: ruby_uninstall
+  run_list: recipe[test::ruby_uninstall]
+  includes: [ubuntu-18.04]
 - name: system_install
   run_list: recipe[test::system_install]
   includes: [centos-7]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Installs a given Ruby version to the system or user location.
 ```ruby
 rbenv_ruby '2.5.1' do
   user # Optional, but recommended: If passed, the user to install rbenv to
-  rbenv_action # Optional: the action to perform, install, remove etc
+  rbenv_action # Optional: the action to perform, 'install' (default), 'uninstall' etc
 end
 ```
 

--- a/test/fixtures/cookbooks/test/recipes/ruby_uninstall.rb
+++ b/test/fixtures/cookbooks/test/recipes/ruby_uninstall.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 system_version = '2.5.1'
-user_version = '2.5.0'
 
 # Make sure that Vagarant user is on the box for dokken
 include_recipe 'test::dokken'
@@ -15,10 +14,7 @@ rbenv_ruby system_version
 # Set System global version
 rbenv_global system_version
 
-# User Install
-rbenv_user_install 'vagrant'
-
-# Install a Ruby to a user directory
-rbenv_ruby user_version do
-  user 'vagrant'
+# Uninstall Ruby
+rbenv_ruby system_version do
+  rbenv_action 'uninstall'
 end

--- a/test/fixtures/cookbooks/test/recipes/ruby_uninstall.rb
+++ b/test/fixtures/cookbooks/test/recipes/ruby_uninstall.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+system_version = '2.5.1'
+user_version = '2.5.0'
+
+# Make sure that Vagarant user is on the box for dokken
+include_recipe 'test::dokken'
+
+# System Install
+rbenv_system_install 'system'
+
+# Install system wide Ruby
+rbenv_ruby system_version
+
+# Set System global version
+rbenv_global system_version
+
+# User Install
+rbenv_user_install 'vagrant'
+
+# Install a Ruby to a user directory
+rbenv_ruby user_version do
+  user 'vagrant'
+end

--- a/test/integration/ruby_uninstall/controls/ruby_uninstall.rb
+++ b/test/integration/ruby_uninstall/controls/ruby_uninstall.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+system_ruby = '2.5.1'
+user_ruby = '2.5.0'
+
+control 'Global Ruby uninstall' do
+  title 'Global Ruby should be uninstalled'
+
+  desc "#{system_ruby} should be uninstalled"
+  describe bash('source /etc/profile.d/rbenv.sh && rbenv versions --bare') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not match(/#{Regexp.quote(system_ruby)}/) }
+  end
+end
+
+control 'Local Ruby uninstall' do
+  title 'Local Ruby should be uninstalled'
+
+  desc "#{user_ruby} should be uninstalled"
+  describe bash('sudo -H -u vagrant bash -c "source /etc/profile.d/rbenv.sh && rbenv versions --bare"') do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not match(/#{Regexp.quote(user_ruby)}/) }
+  end
+end

--- a/test/integration/ruby_uninstall/controls/ruby_uninstall.rb
+++ b/test/integration/ruby_uninstall/controls/ruby_uninstall.rb
@@ -1,24 +1,13 @@
 # frozen_string_literal: true
 
-system_ruby = '2.5.1'
-user_ruby = '2.5.0'
+global_system_ruby = '2.5.1'
 
-control 'Global Ruby uninstall' do
-  title 'Global Ruby should be uninstalled'
+control 'Ruby uninstall' do
+  title 'Ruby should be uninstalled'
 
-  desc "#{system_ruby} should be uninstalled"
+  desc "#{global_system_ruby} should be uninstalled"
   describe bash('source /etc/profile.d/rbenv.sh && rbenv versions --bare') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should_not match(/#{Regexp.quote(system_ruby)}/) }
-  end
-end
-
-control 'Local Ruby uninstall' do
-  title 'Local Ruby should be uninstalled'
-
-  desc "#{user_ruby} should be uninstalled"
-  describe bash('sudo -H -u vagrant bash -c "source /etc/profile.d/rbenv.sh && rbenv versions --bare"') do
-    its('exit_status') { should eq 0 }
-    its('stdout') { should_not match(/#{Regexp.quote(user_ruby)}/) }
+    its('stdout') { should_not match(/#{Regexp.quote(global_system_ruby)}/) }
   end
 end

--- a/test/integration/ruby_uninstall/inspec.yml
+++ b/test/integration/ruby_uninstall/inspec.yml
@@ -1,0 +1,9 @@
+name: rbenv
+title: rbenv profile
+maintainer: Sous Chefs
+copyright: Webb Agile Solutions Ltd.
+license: Apache-2.0
+summary: Verifies rbenv is installed correctly
+version: 1.0.0
+supports:
+  - os-family: linux

--- a/test/integration/ruby_uninstall/inspec.yml
+++ b/test/integration/ruby_uninstall/inspec.yml
@@ -1,9 +1,8 @@
 name: rbenv
 title: rbenv profile
 maintainer: Sous Chefs
-copyright: Webb Agile Solutions Ltd.
 license: Apache-2.0
-summary: Verifies rbenv is installed correctly
+summary: Verifies that Rubies can be uninstalled
 version: 1.0.0
 supports:
   - os-family: linux


### PR DESCRIPTION
### Description

Previously it was impossible to uninstall existing Ruby versions because `ruby_installed?` returned `true`, which skipped the action.

But I am not quite sure how to test this. Install, uninstall and assert that `rbenv versions` returns nothing?

### Issues Resolved

#189

### Contribution Check List

- [x] All tests pass.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/224)
<!-- Reviewable:end -->
