### PR TITLE
Use Regexp.quote for version numbers

### DIFF
--- a/test/integration/gem/controls/gem_install.rb
+++ b/test/integration/gem/controls/gem_install.rb
@@ -13,21 +13,21 @@ control 'Global Gem Install' do
   desc '2.3.1 Gem should have mail installed'
   describe bash('/usr/local/rbenv/versions/2.3.1/bin/gem list --local mail') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(/2.6.5/) }
-    its('stdout') { should_not match(/2.6.6/) }
+    its('stdout') { should match(/#{Regexp.quote('2.6.5')}/) }
+    its('stdout') { should_not match(/#{Regexp.quote('2.6.6')}/) }
   end
 
   desc '2.4.1 Gem should not have any mail version installed'
   describe bash('/usr/local/rbenv/versions/2.4.1/bin/gem list --local') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should_not match(/2.6.5/) }
-    its('stdout') { should_not match(/2.6.6/) }
+    its('stdout') { should_not match(/#{Regexp.quote('2.6.5')}/) }
+    its('stdout') { should_not match(/#{Regexp.quote('2.6.6')}/) }
   end
 
   desc 'gem home should be rbenv in an rbenv directory'
   describe bash('source /etc/profile.d/rbenv.sh && gem env home') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(%r{/usr/local/rbenv/versions/#{Regexp.quote(global_ruby)}/lib/ruby/gems/2.4.0}) }
+    its('stdout') { should match(%r{/usr/local/rbenv/versions/#{Regexp.quote(global_ruby)}/lib/ruby/gems/#{Regexp.quote('2.4.0')}}) }
   end
 end
 

--- a/test/integration/user_install/controls/user_install.rb
+++ b/test/integration/user_install/controls/user_install.rb
@@ -9,7 +9,7 @@ control 'Rbenv should be installed' do
   describe bash('sudo -H -u vagrant bash -c "source /etc/profile.d/rbenv.sh && rbenv global"') do
     its('exit_status') { should eq 0 }
     its('stdout') { should include(global_ruby) }
-    its('stdout') { should_not match(/system/) }
+    its('stdout') { should_not match(/#{Regexp.quote(system)}/) }
   end
 
   describe file('/home/vagrant/.rbenv/versions') do
@@ -22,7 +22,7 @@ control 'ruby-build plugin should be installed' do
   title 'ruby-build should be installed to the users home directory'
   describe bash('sudo -H -u vagrant bash -c "source /etc/profile.d/rbenv.sh && rbenv install -l"') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(/2.3.4/) }
+    its('stdout') { should match(/#{Regexp.quote('2.3.4')}/) }
     its('stdout') { should include(global_ruby) }
   end
 end


### PR DESCRIPTION
### Description

This was already used in [other places](https://github.com/sous-chefs/ruby_rbenv/blob/560b851a9e19a4e72000c995b00e5443f3fb87c7/test/integration/gem/controls/gem_install.rb#L10), this uses it everywhere else as well. But other places just use `include` which might be easier to read and still be a good choice for tests.

The `match` assertion would be more useful if it was extremely strict, at which point we could just use `its ('stdout') { should equal 'foo' }` to have an exact match.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/227)
<!-- Reviewable:end -->
