### PR TITLE
Use include matcher instead of match

### DIFF
--- a/test/integration/gem/controls/gem_install.rb
+++ b/test/integration/gem/controls/gem_install.rb
@@ -7,27 +7,27 @@ control 'Global Gem Install' do
   desc "Can set global Ruby version to #{global_ruby}"
   describe bash('source /etc/profile.d/rbenv.sh && rbenv versions --bare') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(/#{Regexp.quote(global_ruby)}/) }
+    its('stdout') { should include(global_ruby) }
   end
 
   desc '2.3.1 Gem should have mail installed'
   describe bash('/usr/local/rbenv/versions/2.3.1/bin/gem list --local mail') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(/2.6.5/) }
-    its('stdout') { should_not match(/2.6.6/) }
+    its('stdout') { should include('2.6.5') }
+    its('stdout') { should_not include('2.6.6') }
   end
 
   desc '2.4.1 Gem should not have any mail version installed'
   describe bash('/usr/local/rbenv/versions/2.4.1/bin/gem list --local') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should_not match(/2.6.5/) }
-    its('stdout') { should_not match(/2.6.6/) }
+    its('stdout') { should_not include('2.6.5') }
+    its('stdout') { should_not include('2.6.6') }
   end
 
   desc 'gem home should be rbenv in an rbenv directory'
   describe bash('source /etc/profile.d/rbenv.sh && gem env home') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(%r{/usr/local/rbenv/versions/#{Regexp.quote(global_ruby)}/lib/ruby/gems/2.4.0}) }
+    its('stdout') { should include("/usr/local/rbenv/versions/#{global_ruby}/lib/ruby/gems/2.4.0") }
   end
 end
 

--- a/test/integration/user_install/controls/user_install.rb
+++ b/test/integration/user_install/controls/user_install.rb
@@ -9,7 +9,7 @@ control 'Rbenv should be installed' do
   describe bash('sudo -H -u vagrant bash -c "source /etc/profile.d/rbenv.sh && rbenv global"') do
     its('exit_status') { should eq 0 }
     its('stdout') { should include(global_ruby) }
-    its('stdout') { should_not match(/system/) }
+    its('stdout') { should_not include(system) }
   end
 
   describe file('/home/vagrant/.rbenv/versions') do
@@ -22,7 +22,7 @@ control 'ruby-build plugin should be installed' do
   title 'ruby-build should be installed to the users home directory'
   describe bash('sudo -H -u vagrant bash -c "source /etc/profile.d/rbenv.sh && rbenv install -l"') do
     its('exit_status') { should eq 0 }
-    its('stdout') { should match(/2.3.4/) }
+    its('stdout') { should include('2.3.4') }
     its('stdout') { should include(global_ruby) }
   end
 end


### PR DESCRIPTION
### Description

See #227 for a discussion. Basically either using the `match` matcher was not applied correctly (without `Regex.quote`) or just not necessary, because no actual regular expression was being tested.

### Issues Resolved

None.

### Contribution Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/232)
<!-- Reviewable:end -->
