### PR TITLE
Clarify in rbenv_gem docs that specifying user is *required* when using rbenv_user_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ rbenv_gem 'gem_name' do
   version # Optional: Gem version to install
   response_file # Optional: response file to reconfigure a gem
   rbenv_version # Required: Which rbenv version to install the gem to.
+  user # Which user to install gem to. REQUIRED if you're using rbenv_user_install
 end
 ```
 


### PR DESCRIPTION
When using a user-installed rbenv, specifying a user (the user where rbenv is installed) is required to install a gem. I'm not the first to run into this — see discussion on https://github.com/sous-chefs/ruby_rbenv/issues/201#issuecomment-357349185

This just bit me and the docs for `rbenv_gem` strangely don't even show user as an option. Without it, gem install fails with a confusing error message, eg:`Errno::ENOENT: No such file or directory - /versions/2.4.1/bin/gem`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/234)
<!-- Reviewable:end -->
