### PR TITLE
Improved manage 'mac_os_x' platform family (only for Ruby >= 1.9.3-p0…)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.2 (2018-11-09)
+
+- Fix `TypeError: no implicit conversion of nil into String` for `mac_os_x` platforms
 
 # 2.1.1 (2018-10-08)
 

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -6,7 +6,9 @@ class Chef
         when /^jruby-/
           package jruby_package_deps
         else
-          package package_deps
+          package_deps.each do |deps|
+            package deps
+          end
         end
 
         ensure_java_environment if new_resource.version =~ /^jruby-/
@@ -34,6 +36,8 @@ class Chef
 
       def package_deps
         case node['platform_family']
+      	when 'mac_os_x'
+      	  %w(openssl makedepend pkg-config libyaml libffi)
         when 'rhel', 'fedora', 'amazon'
           %w(gcc bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel make)
         when 'debian'

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -36,8 +36,8 @@ class Chef
 
       def package_deps
         case node['platform_family']
-      	when 'mac_os_x'
-      	  %w(openssl makedepend pkg-config libyaml libffi)
+        when 'mac_os_x'
+          %w(openssl makedepend pkg-config libyaml libffi)
         when 'rhel', 'fedora', 'amazon'
           %w(gcc bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel make)
         when 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/sous-chefs/ruby_rbenv'
 license 'Apache-2.0'
 description 'Manages rbenv and installs Rbenv based Rubies'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.1'
+version '2.1.2'
 chef_version '>= 13.0'
 
 supports 'ubuntu'


### PR DESCRIPTION
Improved management for 'mac_os_x' platform family (only for Ruby >= 1.9.3-p0…) 
[TypeError: no implicit conversion of nil into String]
[TypeError: name is required]

### Description

I'm working on an infrastructure with some **Mac servers** that needs `rbenv` to manage ruby installations. 
At the moment I'm using a custom cookbook but I would like able to use these resources for `mac_os_x` platforms; so I was using your resources and I got the error in object.
This setup worked for me, those are dependecies for Mac platforms.
WARN: this commit doesn't work for Ruby versions <= 1.9.3-p0
https://github.com/rbenv/ruby-build/wiki

### Issues Resolved

Could resolve this:
https://github.com/sous-chefs/ruby_rbenv/issues/205

### Contribution Check List

At the moment I'm using this solution in test environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/239)
<!-- Reviewable:end -->
