### PR TITLE
refactored user_install.rb resources group property

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ source_url 'https://github.com/sous-chefs/ruby_rbenv'
 license 'Apache-2.0'
 description 'Manages rbenv and installs Rbenv based Rubies'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.2'
+version '2.1.3'
 chef_version '>= 13.0'
 
 supports 'ubuntu'

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -25,7 +25,7 @@ provides :rbenv_user_install
 property :git_url,      String, default: 'https://github.com/rbenv/rbenv.git'
 property :git_ref,      String, default: 'master'
 property :user,         String, name_property: true
-property :group,        String, default: lazy { user }
+property :group,        String
 property :home_dir,     String, default: lazy { ::File.expand_path("~#{user}") }
 property :user_prefix,  String, default: lazy { ::File.join(home_dir, '.rbenv') }
 property :update_rbenv, [true, false], default: true

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -51,14 +51,14 @@ action :install do
     reference new_resource.git_ref
     action :checkout if new_resource.update_rbenv == false
     user new_resource.user
-    group new_resource.group
+    group new_resource.group if new_resource.group
     notifies :run, 'ruby_block[Add rbenv to PATH]', :immediately
   end
 
   %w(plugins shims versions).each do |d|
     directory "#{new_resource.user_prefix}/#{d}" do
       owner new_resource.user
-      group new_resource.group
+      group new_resource.group if new_resource.group
       mode '0755'
     end
   end


### PR DESCRIPTION
### Description

Fixing ruby_rbenv cookbook and will open PR to the source author changing custom resource

From:
```
property :group,        String, default: lazy { user }
```
To:
```
property :group,        String
```

### Issues Resolved

```
       49:   git new_resource.user_prefix do
       50:     repository new_resource.git_url
       51:     reference new_resource.git_ref
       52:     action :checkout if new_resource.update_rbenv == false
       53:     user new_resource.user
       54:     group new_resource.group <=== not working if custom group is specified
       55:     notifies :run, 'ruby_block[Add rbenv to PATH]', :immediately
       56:   end
       57: 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/243)
<!-- Reviewable:end -->
