### PR TITLE
Remove the unnecessary long_metadata value in metadata.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 
 ## Unreleased
 
+- Remove the unnecessary long_metadata value in metadata.rb
+
 ## 2.3.0
 
 - Allow to specify the root_path so global rbenv install can run rbenv_scripts as non root (#247)

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-fail 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+raise 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  fail 'Please include a CHANGELOG entry.'
+  raise 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,6 @@ issues_url 'https://github.com/sous-chefs/ruby_rbenv/issues'
 source_url 'https://github.com/sous-chefs/ruby_rbenv'
 license 'Apache-2.0'
 description 'Manages rbenv and installs Rbenv based Rubies'
-long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '2.3.0'
 chef_version '>= 13.0'
 


### PR DESCRIPTION
No need for this anymore

Closes #259

Signed-off-by: Tim Smith <tsmith@chef.io>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/267)
<!-- Reviewable:end -->
