### PR TITLE
Using libgdm6 when Debian 10.0 (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,77 +1,83 @@
-# ruby_rbenv Cookbook Changelog
+# Changelog
 
-This file is used to list changes made in each version of the ruby_rbenv cookbook.
+All notable changes to this project will be documented in this file.
 
-## Unreleased
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
 
 - Remove the unnecessary long_metadata value in metadata.rb
+- Fix Debian 10 dependency: libgdm6
 
-## 2.3.0
+## [[2.3.0] -] - 2019-09-30
 
 - Allow to specify the root_path so global rbenv install can run rbenv_scripts as non root (#247)
 
-## 2.2.0 (2019-08-08)
+## [[2.2.0] -] - 2019-08-08
 
 - Use CircleCI 2.0 Orb
 
-## 2.1.3 (2019-07-17)
+## [[2.1.3] -] - 2019-07-17
 
 - Update CircleCI testing orb
 - Update platforms, remove Debian 8 testing support
 
-## 2.1.2 (2018-11-09)
+## [2.1.2] - 2018-11-09
 
 - Fix `TypeError: no implicit conversion of nil into String` for `mac_os_x` platforms
 
-## 2.1.1 (2018-10-08)
+## [2.1.1] - 2018-10-08
 
 - Fixed `rbenv_action` to support actions like `uninstall` (#189)
 
-## 2.1.0 (2018-08-28)
+## [2.1.0] - 2018-08-28
 
 - Drop support for Chef 12
 
-## 2.0.9 (2018-06-12)
+## [2.0.9] - 2018-06-12
 
 - Fix verbose option (#220)
 
-## 2.0.8 (2018-06-09)
+## [2.0.8] - 2018-06-09
 
 - Install the git package rather than the git-core package (#217)
 
-## 2.0.7 (2018-03-11)
+## [2.0.7] - 2018-03-11
 
 - Adding Ubuntu 18.04 support
 - Move all helpers into the helper file
 - Remove rubinius support, that never worked anyway.
 
-## 2.0.6 (2018-01-08)
+## [2.0.6] - 2018-01-08
 
 - Fix rubinius install
 - Add tests for rubinius
 
-## 2.0.5 (2017-10-17)
+## [2.0.5] - 2017-10-17
 
 - Add missing jruby deps #191
 - Update README for general usage
 
-## 2.0.4 (2017-08-17)
+## [2.0.4] - 2017-08-17
 
 - Group support on user install #183
 
-## 2.0.3 (2017-08-04)
+## [2.0.3] - 2017-08-04
 
 - Fix rehash resource #179
 
-## 2.0.2 (2017-08-02)
+## [2.0.2] - 2017-08-02
 
 - Fix gem_install resource so it can install gems to a non-global ruby gem.
 
-## 2.0.1 (2017-08-02)
+## [2.0.1] - 2017-08-02
 
 - Fix user_install resource bug where the script wasn't being called with the correct environment. Fixes #175
 
-## 2.0.0 (2017-07-24)
+## [2.0.0] - 2017-07-24
 
 - Switch libraries to custom resources
 - Use gem install from core Chef
@@ -87,14 +93,14 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 
 - Installing Ruby 2.3.1 on Fedora requires a patched version of 2.3.1\. As patching is currently unavailable please pin to a prior version if you need this installing.
 
-## 1.2.1 (2017-06-23)
+## [1.2.1] - 2017-06-23
 
 - Fixed resource failures on Chef 13
 - Updated the Apache license string to a SPDX compliant string
 - Added Travis testing for Chef 12 and 13
 - Switched testing from Rake to local delivery
 
-## 1.2.0 (2017-04-11)
+## [1.2.0] - 2017-04-11
 
 - Migrated maintenance of this cookbook to Sous Chefs
 - Remove the check to see if the homebrew provider exists since this always exists in Chef 12 and the code failed on Chef 13
@@ -103,7 +109,7 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Removed the "suggests 'java'" metadata as suggests was never implemented in Chef and has been removed from Chef 13
 - Bumped the required Chef release from 12.0 to 12.1
 
-## 1.1.0 (2016-06-17)
+## [1.1.0] - 2016-06-17
 
 - Restored compatibility for platforms that don't yet support multipackage installs in Chef (BSD and OS X in particular)
 - Updated to Grab rbenv from the new repo URL and use https vs. git for compatibility
@@ -116,18 +122,18 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Added a chefignore file to limit the files uploaded to the chef server
 - Switched linting from Rubocop to Cookstyle (rubocop wrapper by Chef)
 
-## 1.0.1 (2015-10-24)
+## [1.0.1] - 2015-10-24
 
 - Fixed failure with rehashing after the cookbook was renamed
 
-## 1.0.0 (2015-10-12)
+## [1.0.0] - 2015-10-12
 
 ### WARNING: Cookbook has been renamed
 
 - Renamed to ruby_rbenv and uploaded to Supermarket (all attributes rename in the rbenv cookbook). If you wrap this cookbook you're going to need to update the recipes you include. All providers have been updated to keep their existing rbenv_xyz names for backwards compatibility and attributes still maintain the rbenv namespace.
 - Updated Travis config to run integration tests in Travis using kitchen-docker
 
-## 0.9.0 (2015-10-12)
+## [0.9.0] - 2015-10-12
 
 - Fixed base platform case statement in the cookbook that set install_pkgs and user_home_root attributes. This has been converted to a platform_family statement to better support derivitive operating systems and the attributes are set at default levels so they can be overwritten in wrapper cookbooks
 - Updated Travis to test using Chef DK vs. Gem installs
@@ -138,7 +144,7 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Removed the empty Vagrant recipe
 - Actually depend on ruby_version vs. suggests since suggests isn't implemented in Chef
 
-## 0.8.1 (2015-08-28)
+## [0.8.1] - 2015-08-28
 
 - Add rbenv_action attribute to rbenv_ruby LWRP so to allow using rvm-download rbenv plugin to download ruby vs. installing ruby
 - Fix the ability to install gems to a specific version of ruby
@@ -146,13 +152,13 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Use default_action method in the LWRPs
 - Fix various rubocop warnings
 
-## 0.8.0 (2015-07-27)
+## [0.8.0] - 2015-07-27
 
 - Drop support for Chef versions prior to 12
 - Add Arch linux support
 - Add Linux mint support
 
-## 0.7.3 (2015-07-8)
+## [0.7.3] - (2015-07-8)
 
 - Issue [#91](https://github.com/fnichol/chef-rbenv/issues/91) [#79](https://github.com/fnichol/chef-rbenv/issues/79) [#92](https://github.com/fnichol/chef-rbenv/pull/92): Add matchers for rbenv_gem and rbenv_ruby. ([@tduffield](https://github.com/tduffield) and many others)
 - Issue [#107](https://github.com/fnichol/chef-rbenv/issues/107): "Option name must be a kind of String!" when installing gems.
@@ -161,13 +167,10 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Issue [#110](https://github.com/fnichol/chef-rbenv/issues/110): Chef 12.3.0 - undefined method `clear_sources' for Chef::Resource::RbenvGem. ([@tatat](https://github.com/tatat) and others)
 - Fork from <https://github.com/fnichol/chef-rbenv>
 
-## 0.7.2 (2012-12-31)
+## [0.7.2] - 2012-12-31
 
 - Pull request [#26](https://github.com/fnichol/chef-rbenv/pull/26): Don't call libexec commands directly. ([@mhoran])
 - Add integration tests for a system Ruby version. ([@fnichol])
-
-## 0.7.1 (unreleased)
-
 - Pull request [#36](https://github.com/fnichol/chef-rbenv/pull/36): Use the ruby name as the definition to install ([@gsandie])
 - Pull request [#55](https://github.com/fnichol/chef-rbenv/pull/55): Fix some CHEF-3694 warnings when using with ruby_build ([@trinitronx])
 
@@ -182,7 +185,7 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Pull request [#75](https://github.com/fnichol/chef-rbenv/pull/75): Update testing support and add unit tests for existing resources ([@fnichol])
 - Pull request [#70](https://github.com/fnichol/chef-rbenv/pull/70): Support ruby 2.1.0 ([@WhyEee])
 
-## 0.7.0 (2012-11-21)
+## [0.7.0] - 2012-11-21
 
 - Issue [#14](https://github.com/fnichol/chef-rbenv/pull/14): Create /etc/profile.d on system-wide and add note for Mac. ([@fnichol])
 - Pull request [#20](https://github.com/fnichol/chef-rbenv/pull/20): Set an attribute to create profile.d for user install. ([@jtimberman])
@@ -190,16 +193,16 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Update foodcritic configuration and update .travis.yml. ([@fnichol])
 - Update Installation section of README (welcome Berkshelf). ([@fnichol])
 
-## 0.6.10 (2012-05-18)
+## [0.6.10] - 2012-05-18
 
 - Pull request [#11](https://github.com/fnichol/chef-rbenv/pull/11): Add FreeBSD support. ([@jssjr])
 - Add other platform supports in metadata.rb and README. ([@fnichol])
 
-## 0.6.8 (2012-05-06)
+## [0.6.8] - 2012-05-06
 
 - Add official hook resource `log[rbenv-post-init-*]` for inter-cookbook integration. ([@fnichol])
 
-## 0.6.6 (2012-05-04)
+## [0.6.6] - 2012-05-04
 
 - Fix FC022: Resource condition within loop may not behave as expected. ([@fnichol])
 - Add plaform equivalents in default attrs (FC024). ([@fnichol])
@@ -210,13 +213,13 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - README updates. ([@fnichol])
 - Confirm debian platform support. ([@fnichol])
 
-## 0.6.4 (2012-02-23)
+## [0.6.4] - 2012-02-23
 
 - Set `root_path` on rbenv_rehash in rbenv_gem provider. ([@fnichol])
 - Foodcritic lint-driven code updates. ([@fnichol])
 - Update Git URL in README. ([@hedgehog])
 
-## 0.6.2 (2012-02-22)
+## [0.6.2] - 2012-02-22
 
 - Issues [#1](https://github.com/fnichol/chef-rbenv/issues/1), [#2](https://github.com/fnichol/chef-rbenv/issues/2): Stub mixins in RbenvRubygems to avoid libraries load ordering issues. ([@fnichol])
 - Pull request [#5](https://github.com/fnichol/chef-rbenv/pull/5): Include user setting in rehash calls. ([@magnetised])
@@ -224,7 +227,7 @@ This file is used to list changes made in each version of the ruby_rbenv cookboo
 - Large formatting updates to README. ([@fnichol])
 - Add gh-pages branch for sectioned README at <https://fnichol.github.com/chef-rbenv>
 
-## 0.6.0 (2011-12-21)
+## [0.6.0] - 2011-12-21
 
 The initial release.
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -25,13 +25,13 @@ def test_changes?
   false
 end
 
-raise 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
+failure 'Please provide a summary of your Pull Request.' if github.pr_body.length < 10
 
 warn 'This is a big Pull Request.' if git.lines_of_code > 400
 
 # Require a CHANGELOG entry for non-test changes.
 if !git.modified_files.include?('CHANGELOG.md') && code_changes?
-  raise 'Please include a CHANGELOG entry.'
+  failure 'Please include a CHANGELOG entry.'
 end
 
 # A sanity check for tests.

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -41,8 +41,10 @@ class Chef
         when 'rhel', 'fedora', 'amazon'
           %w(gcc bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel make)
         when 'debian'
-          if (node['platform'] == 'ubuntu') && (node['platform_version'] == '18.04')
-            %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev make)
+          if platform?('ubuntu') && node['platform_version'].to_i >= 18
+            %w(gcc autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev make)
+          elsif platform?('debian') && node['platform_version'].to_i >= 10
+            %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev make)
           else
             %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev make)
           end


### PR DESCRIPTION
* Update CHANGELOG

* Using libgdm6 when Debian 10.0

# Description

Describe what this change achieves

## Issues Resolved

Closes https://github.com/sous-chefs/ruby_rbenv/issues/266
Closes https://github.com/sous-chefs/ruby_rbenv/issues/261
Actually closes https://github.com/sous-chefs/ruby_rbenv/issues/259

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/269)
<!-- Reviewable:end -->
