### PR TITLE
release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.3.1] - 2019-12-17
 
 ### Fixed
 
@@ -13,15 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Debian 10 dependency: libgdm6
 - Use TrueClass and FalseClass in resources
 
-## [[2.3.0] -] - 2019-09-30
+## [2.3.0] - 2019-09-30
 
 - Allow to specify the root_path so global rbenv install can run rbenv_scripts as non root (#247)
 
-## [[2.2.0] -] - 2019-08-08
+## [2.2.0] - 2019-08-08
 
 - Use CircleCI 2.0 Orb
 
-## [[2.1.3] -] - 2019-07-17
+## [2.1.3] - 2019-07-17
 
 - Update CircleCI testing orb
 - Update platforms, remove Debian 8 testing support

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ issues_url 'https://github.com/sous-chefs/ruby_rbenv/issues'
 source_url 'https://github.com/sous-chefs/ruby_rbenv'
 license 'Apache-2.0'
 description 'Manages rbenv and installs Rbenv based Rubies'
-version '2.3.0'
+version '2.3.1'
 chef_version '>= 13.0'
 
 supports 'ubuntu'


### PR DESCRIPTION
# Description

### Fixed
- Remove the unnecessary long_metadata value in metadata.rb
- Fix Debian 10 dependency: libgdm6 https://github.com/sous-chefs/ruby_rbenv/issues/266
- Use TrueClass and FalseClass in resources

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/272)
<!-- Reviewable:end -->
