### PR TITLE
Fixes for Chef16 changes in git resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ issues_url 'https://github.com/sous-chefs/ruby_rbenv/issues'
 source_url 'https://github.com/sous-chefs/ruby_rbenv'
 license 'Apache-2.0'
 description 'Manages rbenv and installs Rbenv based Rubies'
-version '2.3.2'
+version '2.4.0'
 chef_version '>= 13.0'
 
 supports 'ubuntu'

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -34,6 +34,7 @@ action :install do
     repository new_resource.git_url
     reference new_resource.git_ref
     user new_resource.user if new_resource.user
+    checkout_branch 'deploy'
     action :sync
   end
 end

--- a/resources/system_install.rb
+++ b/resources/system_install.rb
@@ -49,6 +49,7 @@ action :install do
   git new_resource.global_prefix do
     repository new_resource.git_url
     reference new_resource.git_ref
+    checkout_branch 'deploy'
     action :checkout if new_resource.update_rbenv == false
     notifies :run, 'ruby_block[Add rbenv to PATH]', :immediately
     notifies :run, 'bash[Initialize system rbenv]', :immediately

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -49,6 +49,7 @@ action :install do
   git new_resource.user_prefix do
     repository new_resource.git_url
     reference new_resource.git_ref
+    checkout_branch 'deploy'
     action :checkout if new_resource.update_rbenv == false
     user new_resource.user
     group new_resource.group


### PR DESCRIPTION
Chef 16 changed the checkout_branch default from deploy to unset. This causes issues when trying to checkout from master. This workaround fixes it by restoring the old default.