### PR TITLE
Set dependencies properly for Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           - 'centos-7'
           - 'ubuntu-1604'
           - 'ubuntu-1804'
+          - 'ubuntu-2004'
         suite:
           - 'global'
       fail-fast: false

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -59,6 +59,14 @@ platforms:
         - RUN /usr/bin/apt-get update
         - RUN /usr/bin/apt-get install sudo -y
 
+  - name: ubuntu-20.04
+  driver:
+    image: dokken/ubuntu-20.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install sudo -y
+
   - name: opensuse-leap
     driver:
       image: dokken/opensuse-leap

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -60,12 +60,12 @@ platforms:
         - RUN /usr/bin/apt-get install sudo -y
 
   - name: ubuntu-20.04
-  driver:
-    image: dokken/ubuntu-20.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install sudo -y
+    driver:
+      image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install sudo -y
 
   - name: opensuse-leap
     driver:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,6 +18,7 @@ platforms:
   - name: debian-9
   - name: ubuntu-16.04
   - name: ubuntu-18.04
+  - name: ubuntu-20.04
   - name: opensuse-leap
 
 suites:

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -41,7 +41,9 @@ class Chef
         when 'rhel', 'fedora', 'amazon'
           %w(gcc bzip2 openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel gdbm-devel ncurses-devel make)
         when 'debian'
-          if platform?('ubuntu') && node['platform_version'].to_i >= 18
+          if platform?('ubuntu') && node['platform_version'].to_i >= 20
+            %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev make)
+          elsif platform?('ubuntu') && node['platform_version'].to_i >= 18
             %w(gcc autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev make)
           elsif platform?('debian') && node['platform_version'].to_i >= 10
             %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev make)


### PR DESCRIPTION
Ruby requires some different dependencies for installation in Ubuntu 20.04 -- this PR provides them, and adds Ubuntu 20.04 as a target for test kitchen.