### PR TITLE
Add bzip2 as additional dependency for suse

### DIFF
--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -51,7 +51,7 @@ class Chef
             %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm3 libgdbm-dev make)
           end
         when 'suse'
-          %w(gcc make automake gdbm-devel libyaml-devel ncurses-devel readline-devel zlib-devel libopenssl-devel )
+          %w(gcc make automake gdbm-devel libyaml-devel ncurses-devel readline-devel zlib-devel libopenssl-devel bzip2)
         end
       end
     end


### PR DESCRIPTION
# Description

This change fixes converge on opensuse leap 15. Right now it is failing, as no archive binary is installed. The bzip2 package solves this.

## Issues Resolved

-

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
