### PR TITLE
Fix libssl-dev dependency for Ubuntu 18.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Add placeholder for spec directory to tests run properly
 - Fix InSpec tests
+- Fix Ubuntu 18.04 dependency: libssl-dev
 
 ## 2.5.0 - 2020-07-24
 

--- a/libraries/package_deps.rb
+++ b/libraries/package_deps.rb
@@ -44,7 +44,7 @@ class Chef
           if platform?('ubuntu') && node['platform_version'].to_i >= 20
             %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm-dev make)
           elsif platform?('ubuntu') && node['platform_version'].to_i >= 18
-            %w(gcc autoconf bison build-essential libssl1.0-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev make)
+            %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm5 libgdbm-dev make)
           elsif platform?('debian') && node['platform_version'].to_i >= 10
             %w(gcc autoconf bison build-essential libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev libffi-dev libgdbm6 libgdbm-dev make)
           else


### PR DESCRIPTION
# Description

46b6bde5 seemed to focus on fixing a dependency for Debian 10, however in doing so it swapped the libssl-dev dependency for Ubuntu 18.04 to be libssl1.0-dev. Ruby 2.4+ is compatible with OpenSSL 1.1, so you'd only need OpenSSL 1.0 if you were installing Ruby 2.3 or older, none of which  are currently supported by Ruby.

This regression created a conflict with libmysqlclient-dev as it depends on libssl-dev (at least as of v5.7.31), so if you install libmysqlcient-dev first, it'll install libssl-dev, then if you use this cookbook, it'll install libssl1.0-dev, which conflicts with libssl-dev, thus removing libssl-dev and libmysqlclient-dev, breaking anything that tries to load the MySQL development files, such as the mysql2 gem.

## Issues Resolved

None

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
