### PR TITLE
Remove workaround for chef bug in git resource (fixes #289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+**NOTE:** Some Chef version >=16 and <16.4.41 have a bug in the git resource causing some failues (see [#289](https://github.com/sous-chefs/ruby_rbenv/issues/289)). If you experience any troubles please try a more recent version of Chef 16.
+
 - Remove workaround for chef bug in git resource (fixes #289)
 
 ## 2.5.1 - 2020-08-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Remove workaround for chef bug in git resource (fixes #289)
+
 ## 2.5.1 - 2020-08-20
 
 - Add placeholder for spec directory to tests run properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-**NOTE:** Some Chef version >=16 and <16.4.41 have a bug in the git resource causing some failues (see [#289](https://github.com/sous-chefs/ruby_rbenv/issues/289)). If you experience any troubles please try a more recent version of Chef 16.
+**NOTE:** Some Chef versions (>= 16 and < 16.4.41) have a bug in the git resource causing some failures (see [#289](https://github.com/sous-chefs/ruby_rbenv/issues/289)). If you experience any troubles please try a more recent version of Chef 16.
 
 - Remove workaround for chef bug in git resource (fixes #289)
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 This cookbook requires Chef 13.0+.
 
+**NOTE:** Some Chef version >=16 and <16.4.41 have a bug in the git resource causing some failues (see [#289](https://github.com/sous-chefs/ruby_rbenv/issues/289)). If you experience any troubles please try a more recent version of Chef 16.
+
 ### Platform
 
 - Debian derivatives

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 This cookbook requires Chef 13.0+.
 
-**NOTE:** Some Chef version >=16 and <16.4.41 have a bug in the git resource causing some failues (see [#289](https://github.com/sous-chefs/ruby_rbenv/issues/289)). If you experience any troubles please try a more recent version of Chef 16.
+**NOTE:** Some Chef versions (>= 16 and < 16.4.41) have a bug in the git resource causing some failures (see [#289](https://github.com/sous-chefs/ruby_rbenv/issues/289)). If you experience any troubles please try a more recent version of Chef 16.
 
 ### Platform
 

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -34,7 +34,6 @@ action :install do
     repository new_resource.git_url
     reference new_resource.git_ref
     user new_resource.user if new_resource.user
-    checkout_branch 'deploy'
     action :sync
   end
 end

--- a/resources/system_install.rb
+++ b/resources/system_install.rb
@@ -49,7 +49,6 @@ action :install do
   git new_resource.global_prefix do
     repository new_resource.git_url
     reference new_resource.git_ref
-    checkout_branch 'deploy'
     action :checkout if new_resource.update_rbenv == false
     notifies :run, 'ruby_block[Add rbenv to PATH]', :immediately
     notifies :run, 'bash[Initialize system rbenv]', :immediately

--- a/resources/user_install.rb
+++ b/resources/user_install.rb
@@ -49,7 +49,6 @@ action :install do
   git new_resource.user_prefix do
     repository new_resource.git_url
     reference new_resource.git_ref
-    checkout_branch 'deploy'
     action :checkout if new_resource.update_rbenv == false
     user new_resource.user
     group new_resource.group


### PR DESCRIPTION
# Description

Chef bug for git resource seems to be fixed/working now removing workaround (fixes #289) 

I think minor is appropriate given the scope of changes but we may want to bump the major to avoid startling users who may be on the chef versions affected by the bug.

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
