### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'ruby_rbenv'
+
+default_source :supermarket
+
+run_list 'test::default'
+
+cookbook 'ruby_rbenv', path: '.'
+cookbook 'test', path: 'test/cookbooks/test'
+
+Dir.entries('./test/cookbooks/test/recipes').select { |f| f.end_with?('.rb') }.each do |test|
+  test = test.delete_suffix('.rb')
+  named_run_list :"#{test}", "test::#{test}"
+end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -38,23 +38,21 @@ suites:
     provisioner:
       enforce_idempotency: false
       multiple_converge: 1
-    run_list:
-      - recipe[test::gem]
+      named_run_list: gem
   - name: global
-    run_list:
-      - recipe[test::global]
+    provisioner:
+      named_run_list: global
   - name: ruby_uninstall
     provisioner:
       enforce_idempotency: false
       multiple_converge: 1
-    run_list:
-      - recipe[test::ruby_uninstall]
+      named_run_list: ruby_uninstall
   - name: system_install
-    run_list:
-      - recipe[test::system_install]
+    provisioner:
+      named_run_list: system_install
   - name: user_install
-    run_list:
-      - recipe[test::user_install]
+    provisioner:
+      named_run_list: user_install
   - name: custom_group_install
-    run_list:
-      - recipe[test::custom_group_install]
+    provisioner:
+      named_run_list: custom_group_install

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- replace Berksfile with Policyfile.rb
- switch ChefSpec to Policyfile support
- update Copilot setup to run chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- /opt/homebrew/bin/markdownlint-cli2 "**/*.md"
- env GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sous-chefs/ruby_rbenv/364)
<!-- Reviewable:end -->
